### PR TITLE
88 Finalize English Content

### DIFF
--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -27,9 +27,9 @@ _Itabo elementary school director(far left), 6th history and Spanish teacher (fa
 
 Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. It was extended to five weeks and we redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers.
 
-### About the Students
+### About the 2008 Students
 
-Thirty-five students were admitted and completed the program. (MACILE targets talented students in the top 20% of their class.) There was a required orientation and a meeting with the parents .
+MACILE targets talented students in the top 20% of their class. Thirty-five students were admitted and completed the program. There was a required orientation and a meeting with the parents.
 
 ### Schedule and Evaluation
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -57,10 +57,6 @@ _Visit from a Dominican business leader and a government official. They spoke ab
 
 _Teacher Development. Dominican math teachers participating in two week long math training workshop: improving learning of Basic Algebra._
 
-## First Scholars
-
-MACILE granted five merit-based scholarships in 2008 to 9th-grade students from Itabo and San Gregorio de Nigua. School teachers and directors recommended them. The recommendations were green-lighted by community leaders who attested of the students' characters and needs.
-
 ## MACILE Scholarship Program
 
 The program was founded in 2008 with a generous donation from Buffalo Tungstein, Inc.
@@ -68,6 +64,10 @@ The program was founded in 2008 with a generous donation from Buffalo Tungstein,
 MACILE pre-college scholarships encourage academic excellence. The program increases opportunities for qualified young people from less advantaged backgrounds, who are interested in math, science, technology, and engineering to attend more challenging schools and pursue their dreams of education.
 
 The program began in 2008. It's open to students in grade 7th to 12th who have participated in the MACILE Summer Academy. The amount of each scholarship varies depending on the school—each covers tuition (when applicable), uniform, books, supplies, and transportation costs. We hope to be able to offer 40-50 pre-college scholarships per year by 2012. 
+
+### First Scholars
+
+MACILE granted five merit-based scholarships in 2008 to 9th-grade students from Itabo and San Gregorio de Nigua. School teachers and directors recommended them. The recommendations were green-lighted by community leaders who attested of the students' characters and needs.
 
 _Luiz Manuel Alburquerque, 9th grade, Colegio Padre Zegri, Nigua._
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -12,21 +12,21 @@ _High school students from Itabo y San Gregorio de Nigua selected for the FIRST 
 - Advance engineering education in K-12
 - Increase learning and understanding.
 
-## MACILE 2007 Summer Academy
+## MACILE Summer Academy 2007
 
 Forty-seven students completed the 2007 MACILE Summer Academy. It lasted for three weeks and only included mathematics. Students attended from 8:00 AM to 12:00 PM, Monday through Friday. We provided a healthy breakfast snack. At the end of the program, we celebrated with a barbeque.
 
-_A group of 7th-8th grade students from the MACILE Summer Academy 2007 at the barbeque. Students came from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Pinales (center right), Dominican teacher that recruited the students (top right)._
+_A group of 7th-8th grade students from the MACILE Summer Academy 2007 at the barbeque. Students came from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Soriano (center right), Dominican teacher who recruited the students (top right)._
 
 ### People that made a difference
 
-Local educators helped us out by visiting the schools and helping select potential students. They provided MACILE space and also assisted with logistics.
+Local educators and community leaders made the success of MACILE possible. They visited the schools to promote MACILE and encourage students participation. They provided the space for the program and assisted with logistics. 
 
-_Itabo elementary school director(far left), 6th history and Spanish teacher (far right), and community leaders._
+_Itabo elementary school director(far left), 6th grade history and Spanish teacher (far right), and community leaders._
 
 ## MACILE Summer Academy 2008
 
-Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. We extended the program to five weeks, and we redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers.
+Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. We extended the program to five weeks, and redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers.
 
 ### About the 2008 Program
 
@@ -40,11 +40,11 @@ _Spanish teacher, Antonia Asencio (seating, center), and students, proudly showi
 
 ## MACILE Spanish Curriculum
 
-An innovative active approach to deepen understanding of the language through the history and folklore of the Dominican Republic. Dr. Rosario Montelongo de Swanson wrote a book exclusively for MACILE.
+The Spanish curriculum, featured in 2008, is an innovative active approach to deepen understanding of the language through the history, literature, and folklore of the Dominican Republic and Latin America. It was written exclusevely for MACILE by Dr. Rosario Montelongo de Swanson.
 
 ### Los Indios De Quisqueya
 
-Los Indios de Quisqueya, the accompanying history book and foundation of the MACILE curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares Kelnes, permitted its use.
+Los Indios de Quisqueya, the accompanying history book and foundation of the MACILE Spanish curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares Kelnes, permitted its use.
 
 _Learning language and enjoying the folklore. Students dancing at the bits of the drum and güira, singing the "salve," learning Spanish._
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -5,16 +5,24 @@ MACILE targets talented students in the top 20% of their class.  We piloted the 
 
 _High school students from Itabo y San Gregorio de Nigua selected for the FIRST MACILE Summer Academy, July 2007._
 
-## Objectives
+## Our objectives
 
+MACILE has four core objectives:
 - Nurture the creativity and curiosity of talented young people.
 - Increase access to challenging and stimulating learning environments.
 - Advance engineering education in K-12
-- Increase learning and understanding.
+- Intill passion for learning and understanding.
 
-## MACILE Summer Academy 2007
+## About the students
 
-Forty-seven students completed the 2007 MACILE Summer Academy. It lasted for three weeks and only included mathematics. Students attended from 8:00 AM to 12:00 PM, Monday through Friday. We provided a healthy breakfast snack. At the end of the program, we celebrated with a barbeque.
+In 2007, forty-seven students in grade 7th to 11th completed the Summer Academy. The students ranged in age from 12 to 18; 43% were female and 56% male. They came from five public schools. 
+
+In 2008, we admitted thirty-five students to the MACILE Summer Academy, and all successfully completed the program. The students were in grade 6th to 9th; 44% were female and 66% male. They came from five public and private schools. 
+
+
+## MACILE Summer Academy 2007  
+
+The MACILE Summer Academy lasted for three weeks in 2007, and only included mathematics. Students attended from 8:00 AM to 12:00 PM, Monday through Friday. We provided a healthy breakfast snack. At the end of the program, we celebrated with a barbeque. 
 
 _A group of 7th-8th grade students from the MACILE Summer Academy 2007 at the barbeque. Students came from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Soriano (center right), Dominican teacher who recruited the students (top right)._
 
@@ -26,13 +34,13 @@ _Itabo elementary school director(far left), 6th grade history and Spanish teach
 
 ## MACILE Summer Academy 2008
 
-Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. We extended the program to five weeks, and redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers.
+Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. We extended the program to five weeks, and redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers. Students attended from 8:00 AM to 3:30 PM and were provided with a healthy lunch in addition to breakfast.
 
-### About the 2008 Program
+### Students selection and evaluation
 
-We admitted thirty-five students. We added a required orientation and a meeting with the parents before initiating the program.
+Conforming to the MACILE objectives, in 2008 we instituted more riguruous students selection and evaluation processes, aligning more closely with the goal of selecting students from the top 20% of their class who express interest in learning math and science. That year, thirty-five students from fifty-nine recommended were admitted to the MACILE Summer Academy. 
 
-We extended the school day from 12-4 PM and provided students with a healthy lunch in addition to breakfast. We gauged the students' mathematical and linguistic progress through a math test, and an evaluation questionnaire completed at the end of the program.
+We added a required orientation and a meeting with the parents before initiating the program. At the end of the program, we employed particularly design evaluation instruments to gauge the students' mathematical and linguistic progress. We also evaluated the students' perception of learning and overal satisfaction with the program. 
 
 _MACILE Summer Academy 2007-2008. Conducted at the Itabo Elementary School in Itabo, San Critóbal._
 
@@ -40,11 +48,12 @@ _Spanish teacher, Antonia Asencio (seating, center), and students, proudly showi
 
 ## MACILE Spanish Curriculum
 
-The Spanish curriculum, featured in 2008, is an innovative active approach to deepen understanding of the language through the history, literature, and folklore of the Dominican Republic and Latin America. It was written exclusevely for MACILE by Dr. Rosario Montelongo de Swanson.
+The objective of this unique program is twofold: first, it seeks to improve the students’ command of the language, its grammatical structures and orthography; second, it seeks to instruct the student in Dominican culture, history, and literature. To fulfill this double objective, the curriculum includes a selection of Dominican texts that deal with the main roots of Dominican culture: Aboriginal, African and Spanish. The pilot program starts with the deepest root, the Taíno, based mainly on the text Los indios de Quisqueya by Juan Tomás Tavares K., and supplemented by additional material.
 
-### Los Indios De Quisqueya
+### About the author
 
-Los Indios de Quisqueya, the accompanying history book and foundation of the MACILE Spanish curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares Kelnes, permitted its use.
+The Spanish language program has been exclusively developed for MACILE by Dr. Rosario Montelongo de Swanson (link to college page), Professor of Language and Literature at Marlboro College.  “With this program I carry out my desire to contribute to the construction of a better future through youth education and returning to the community a little of how much I have been given as a woman and teacher.”
+
 
 _Learning language and enjoying the folklore. Students dancing at the bits of the drum and güira, singing the "salve," learning Spanish._
 
@@ -52,15 +61,15 @@ _Students built toothpick bridges and learned about solar energy. This team is t
 
 _MACILE strives to expand the young people's horizons, nourishing their innate curiosity and wonderful imagination rather than discouraging them, as Einstein admonished_
 
-_A visit from a Dominican business leader and a government official. They spoke about the job market. Students learned about opportunities and requirements for government scholarship programs._
+_A visit from a Dominican business leader and a government official. They spoke about the job market and the goverment scholarship programs. Students learned about available opportunities and requirements._
 
-_Teacher Development. Dominican math teachers participating in a two-week-long math training workshop: Improving the Learning of Basic Algebra._
+_Teacher Development. Dominican teachers participating in a two-week-long math training workshop: Improving the Learning of Basic Algebra._
 
 ## MACILE Scholarship Program
 
-MACILE pre-college scholarships encourage academic excellence. The program increases opportunities for qualified young people from less advantaged backgrounds, who are interested in math, science, technology, and engineering to attend more challenging schools and pursue their dreams of education.
+The MACILE scholarship program seeks to improve academic achievement among talented young people from the Itabo - San Gregorio de Nigua región in the Dominican Republic, who are passionate about learning and have indicated interest in math and science.  The program increases their opportunities to pursue their preparatory education at top schools in the province.  We hope to encourage students from less-advantaged backgrounds to pursue studies and careers in math, science, technology, and engineering. 
 
-It's open to students in grades 7th to 12th who have participated in the MACILE Summer Academy. The amount of each scholarship varies depending on the school—each covers tuition (when applicable), uniform, books, supplies, and transportation costs_
+The scholarship program is based on academic merit and is open to students in grades 7th to 12th who have participated in the MACILE Summer Academy._
 
 The program was founded in 2008 with a generous donation from Buffalo Tungstein, Inc.
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -19,7 +19,7 @@ _Group of 7th-8th grade students from schools in Itabo, Nigua, El 18, Yogo Yogo,
 
 ### People that made a difference
 
-Local educators helped us out. They visitted the schools and helped select potential students. They provided us the spac and also assisted with logistics.
+Local educators helped us out. They visitted the schools and helped select potential students. They provided us the space and also assisted with logistics.
 
 _Itabo elementary school director(far left), 6th history and Spanish teacher (far right), and community leaders._
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -60,7 +60,7 @@ _Teacher Development. Dominican math teachers participating in a two-week-long m
 
 MACILE pre-college scholarships encourage academic excellence. The program increases opportunities for qualified young people from less advantaged backgrounds, who are interested in math, science, technology, and engineering to attend more challenging schools and pursue their dreams of education.
 
-It's open to students in grades 7th to 12th who have participated in the MACILE Summer Academy. The amount of each scholarship varies depending on the school—each covers tuition (when applicable), uniform, books, supplies, and transportation costs. We hope to be able to offer 40-50 pre-college scholarships per year by 2012. 
+It's open to students in grades 7th to 12th who have participated in the MACILE Summer Academy. The amount of each scholarship varies depending on the school—each covers tuition (when applicable), uniform, books, supplies, and transportation costs_
 
 The program was founded in 2008 with a generous donation from Buffalo Tungstein, Inc.
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -1,6 +1,7 @@
 # We are the adventurers—-the true founders
 
-The MACILE Summer Academy is a rigorous five-week program for students in grades 6 to 12. The curriculum includes math, science, engineering, technology, and language. We designed the courses and activities to stimulate curiosity, creativity, and passion for learning; and to build the students’ skills, analytical abilities, and rational thinking. 
+The MACILE Summer Academy is a rigorous five-week program for students in grades 6 to 12. The curriculum includes math, science, engineering, technology, and language. We designed the courses and activities to stimulate curiosity, creativity, and passion for learning; and to build the students’ skills and logical abilities. 
+
 MACILE targets talented students in the top 20% of their class.  We piloted the program in July 207 and 2008.
 
 _High school students from Itabo y San Gregorio de Nigua selected for the FIRST MACILE Summer Academy, July 2007._
@@ -10,49 +11,52 @@ _High school students from Itabo y San Gregorio de Nigua selected for the FIRST 
 MACILE has four core objectives:
 - Nurture the creativity and curiosity of talented young people.
 - Increase access to challenging and stimulating learning environments.
-- Advance engineering education in K-12
+- Advance engineering, science, and math education in K-12
 - Intill passion for learning and understanding.
 
 ## About the students
 
-In 2007, forty-seven students in grade 7th to 11th completed the Summer Academy. The students ranged in age from 12 to 18; 43% were female and 56% male. They came from five public schools. 
+In 2007, forty-seven students in grade 7th to 11th completed the MACILE Summer Academy. They ranged in age from 12 to 18; 43% were female and 56% male. 
 
-In 2008, we admitted thirty-five students to the MACILE Summer Academy, and all successfully completed the program. The students were in grade 6th to 9th; 44% were female and 66% male. They came from five public and private schools. 
+In 2008, we admitted thirty-five students to the MACILE Summer Academy, and all completed the program. The students were in grade 6th to 9th; 44% were female and 66% male.
 
+The students came from five public and private schools. 
 
 ## MACILE Summer Academy 2007  
 
 The MACILE Summer Academy lasted for three weeks in 2007, and only included mathematics. Students attended from 8:00 AM to 12:00 PM, Monday through Friday. We provided a healthy breakfast snack. At the end of the program, we celebrated with a barbeque. 
 
-_A group of 7th-8th grade students from the MACILE Summer Academy 2007 at the barbeque. Students came from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Soriano (center right), Dominican teacher who recruited the students (top right)._
+_A group of 7th-8th grade students from the MACILE Summer Academy 2007. Students came from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Soriano, Dominican teacher who recruited the students (far right)._
 
 ### People that made a difference
 
-Local educators and community leaders made the success of MACILE possible. They visited the schools to promote MACILE and encourage students participation. They provided the space for the program and assisted with logistics. 
+Local educators and community leaders made the success of MACILE possible. They visited the schools to promote MACILE and encourage students' participation. They also provided the space for the program and assisted with logistics.  
 
-_Itabo elementary school director(far left), 6th grade history and Spanish teacher (far right), and community leaders._
+_Itabo Elementary School director, Bernarda N Lorenzo (far left), 6th-grade history and Spanish teacher, Yahaira Soriano (far right), and Haina Lion Club leaders (center); 2007._
 
 ## MACILE Summer Academy 2008
 
-Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. We extended the program to five weeks, and redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers. Students attended from 8:00 AM to 3:30 PM and were provided with a healthy lunch in addition to breakfast.
+Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. We extended the program to five weeks and redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers. Students attended from 8:00 AM to 3:30 PM and received a healthy lunch in addition to breakfast.
 
 ### Students selection and evaluation
 
-Conforming to the MACILE objectives, in 2008 we instituted more riguruous students selection and evaluation processes, aligning more closely with the goal of selecting students from the top 20% of their class who express interest in learning math and science. That year, thirty-five students from fifty-nine recommended were admitted to the MACILE Summer Academy. 
+In 2008, we instituted more rigorous student selection and evaluation processes, aligning more closely with the MACILE Summer Academy objectives to select students from the top 20% of their class who express interest in learning math and science. That year, we accepted thirty-five from fifty-nine students recommended. 
 
-We added a required orientation and a meeting with the parents before initiating the program. At the end of the program, we employed particularly design evaluation instruments to gauge the students' mathematical and linguistic progress. We also evaluated the students' perception of learning and overal satisfaction with the program. 
+We added a required orientation and a meeting with the parents before initiating the program. At the end of the program, we gauged the students' mathematical and linguistic progress. We also evaluated their perception of learning and overall satisfaction with the program. 
+ 
 
-_MACILE Summer Academy 2007-2008. Conducted at the Itabo Elementary School in Itabo, San Critóbal._
+_MACILE Summer Academy 2007-2008. Conducted at the Itabo Elementary School in Itabo, San Critóbal._ 
+
+Five schools participated in the program: Itabo Elementary, Itabo; Yogo Yogo Elementary, Nigua; Siglo XXI Elementary, Bajos de Haina; Juan Bosch High School, Nigua; Colegio Padre Zegrí, Nigua; and Nueva Escuela, Haina.
+
 
 _Spanish teacher, Antonia Asencio (seating, center), and students, proudly showing resources used to improve their learning._
 
 ## MACILE Spanish Curriculum
 
-The objective of this unique program is twofold: first, it seeks to improve the students’ command of the language, its grammatical structures and orthography; second, it seeks to instruct the student in Dominican culture, history, and literature. To fulfill this double objective, the curriculum includes a selection of Dominican texts that deal with the main roots of Dominican culture: Aboriginal, African and Spanish. The pilot program starts with the deepest root, the Taíno, based mainly on the text Los indios de Quisqueya by Juan Tomás Tavares K., and supplemented by additional material.
+An innovative active approach to improve the students’ command of the language, its grammatical structures, and orthography through a more in-depth understanding of the Dominican culture, folklore, history, and literature. The curriculum includes a selection of Dominican texts that deal with the primary roots of Dominican culture: Aboriginal, African, and Spanish. The pilot program starts with the deepest of them, the Taíno, based mainly on the text Los Indios de Quisqueya by Juan Tomás Tavares K., and supplemented by additional material.
 
-### About the author
-
-The Spanish language program has been exclusively developed for MACILE by Dr. Rosario Montelongo de Swanson (link to college page), Professor of Language and Literature at Marlboro College.  “With this program I carry out my desire to contribute to the construction of a better future through youth education and returning to the community a little of how much I have been given as a woman and teacher.”
+The curriculum has been exclusively written for MACILE by Dr. Rosario Montelongo de Swanson, Professor of Language and Literature at Marlboro College.
 
 
 _Learning language and enjoying the folklore. Students dancing at the bits of the drum and güira, singing the "salve," learning Spanish._
@@ -61,13 +65,13 @@ _Students built toothpick bridges and learned about solar energy. This team is t
 
 _MACILE strives to expand the young people's horizons, nourishing their innate curiosity and wonderful imagination rather than discouraging them, as Einstein admonished_
 
-_A visit from a Dominican business leader and a government official. They spoke about the job market and the goverment scholarship programs. Students learned about available opportunities and requirements._
+_A visit from a Dominican business leader and a government official. They spoke about the job market and government scholarship programs. Students learned about available opportunities and requirements._
 
 _Teacher Development. Dominican teachers participating in a two-week-long math training workshop: Improving the Learning of Basic Algebra._
 
 ## MACILE Scholarship Program
 
-The MACILE scholarship program seeks to improve academic achievement among talented young people from the Itabo - San Gregorio de Nigua región in the Dominican Republic, who are passionate about learning and have indicated interest in math and science.  The program increases their opportunities to pursue their preparatory education at top schools in the province.  We hope to encourage students from less-advantaged backgrounds to pursue studies and careers in math, science, technology, and engineering. 
+The MACILE scholarship program seeks to improve academic achievement among talented young people from the Itabo - San Gregorio de Nigua region in the Dominican Republic. It provides opportunities for youth passionate about learning, which indicates an interest in math and science, to pursue their preparatory education. We hope to encourage students from less-advantaged backgrounds to pursue studies and careers in math, science, technology, and engineering. 
 
 The scholarship program is based on academic merit and is open to students in grades 7th to 12th who have participated in the MACILE Summer Academy._
 
@@ -86,3 +90,33 @@ _Luz B. Pinalez, 9th grade, Instituto Politécnico Loyola, San Cristóbal._
 _Albania Martinez, 9th grade, Loyola, San Cristóbal._
 
 _Andreina De Jesús T., 9th grade, Colegio Padre Zegri, Nigua._
+
+
+# Comments & Acknowledgments 
+
+We recognize the contributions and heartfelt comments of the people, companies, and communities that characterize MACILE. The are invaluable. Without them, improving the program and meeting its objectives would be difficult.
+
+## From Our Students 
+
+This program helped me fall in love with mathematics and language. It gave me new dreams and hopes. I have no words to express my gratitude to MACILE for bringing us what I like best, science, and for instilling in me a passion for learning.
+
+This summer, I learned to read better, how to express my thoughts, and how to analyze problems...
+
+I learned many examples of good behavior, capitalization...
+
+I learned a lot about bridges, solar energy, mathematics, and other things. I also learned that I should not speak with a loud voice and not to disturb others. I also learned that working on a team is extremely important to achieve my goals.
+
+I learned that I should ask questions when in doubt. If I remain silent, I will never learn what I need to learn. 
+
+## Acknowledgments
+
+Buffalo Tungsten, Inc., a private U.S. corporation, is the principal supporter of  MACILE , an education program of Complex Systems Optimization Laboratory.
+
+The Language and Grammar Program was generously written for MACILE by Rosario de Swanson, Ph.D., Professor of Language and Literature at Marlboro College, U.S.A.
+
+Los Indios de Quisqueya, history book of the Tainos in the Hispaniola, and foundation of the MACILE Spanish curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares K., permitted its use without reservations.
+
+
+Dominican teachers, school directors, and school secretaries made the 2007 and 2008 MACILE Summer Academy possible. These remarkable women volunteered to teach and to receive the required training. They promoted MACILE among the schools, encouraged students to apply, motivated other teachers to participate, secured space for the academy, and provided administrative support. The teachers are Yahaira Soriano from Itabo, Antonia Asencio, and Gladys Vizcaíno from Colegio Padre Zegrí. 
+Directors Bernarda N Lorenzo, Itabo Elementary School, and Sor Isabel Jiménez, Colegio Padre Zegrí ensured a home for MACILE in Itabo - San Gregorio de Nigua region.  Administrative assistant Sandra Pinales kept meticulous account of all the records.  
+

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -41,9 +41,9 @@ _Spanish teacher, Antonia Asencio (seating, center), and students, proudly showi
 
 ## MACILE Spanish Curriculum
 
-### Los Indios De Quisqueya
-
 An innovative active approach to deepen understanding of the language through the history and folblore of the Dominican Republic. A book written exclusively for MACILE by Dr. Rosario Montelongo de Swanson.
+
+### Los Indios De Quisqueya
 
 Los indios de Quisqueya, the accompaning history book and foundation of the MACILE curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares Kelnes, permited its use.
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -1,0 +1,76 @@
+# We are the adventurers
+
+We are the adventurers; the true founders. High school students from Itabo y San Gregorio de Nigua selected for the FIRST MACILE Summer Academy, Jul 2007.
+
+## MACILE Summer Academy
+
+The MACILE Summer Academy is a rigorous five week program for students in grades 6 to 12. The curriculum includes math, science, engineering, technology, and language. Courses and activities are designed to stimulate curiosity, creativity, and passion for learning; also to build the students’ skills, analytical abilities, and rational thinking. The program was piloted in July 2007 and 2008.
+
+The 2007 MACILE Summer Academy lasted for three weeks and included mathematics only. Forty-seven students completed the program. They attended from 8:00 AM to 12:00 PM, Monday through Friday, and a healthy breakfast snack was provided. We celebrated the end of the summer with a barbeque.
+
+_People that made a difference. Itabo elementary school director(far left), 6th history and Spanish teacher (far right), and community leaders. They visited the schools, selected students, provided the space, and assisted with logistics_
+
+_MACILE Summer Academy 2007. Group of 7th-8th grade students from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Pinales (far right), Dominican teacher that recruited the students._
+
+### Objectives
+
+- Nurture the creativity and curiosity of talented young people.
+- Increase access to challenging and stimulating learning environments.
+- Advance engineering education in K-12
+- Increase learning and understanding.
+
+## MACILE Summer Academy 2008
+
+Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. It was extended to five weeks and we redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers.
+
+### About the Students
+
+Thirty-five students were admitted and completed the program. (MACILE targets talented students in the top 20% of their class.) There was a required orientation and a meeting with the parents .
+
+### Schedule and Evaluation
+
+We extended the school day from 12-4PM and provided students with a healthy lunch in addition to breakfast. We gauged the students' mathematical and linguistic progress through a math test, and an evaluation questionnaire completed at the end of the program.
+
+_MACILE Summer Academy 2007-2008. Conduceted at the Itabo Elementary School in Itabo, San Critóbal._
+
+_Spanish teacher, Antonia Asencio (seating, center), and students, proudly showing resources used to improve their learning._
+
+## MACILE Spanish Curriculum
+
+### Los Indios De Quisqueya
+
+An innovative active approach to deepen understanding of the language through the history and folblore of the Dominican Republic. A book written exclusively for MACILE by Dr. Rosario Montelongo de Swanson.
+
+Los indios de Quisqueya, the accompaning history book and foundation of the MACILE curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares Kelnes, permited its use.
+
+_Learning language and enjoying the folklore. Students dancing at the bits of the drum and güira, singing the "salve",learning Spanish._
+
+_Students built toothpick bridges and learned about solar energy. This team is testing their bridge resistance._
+
+_MACILE strives to expand the young people's horizons,nourishing their innate curiosity and wonderful imagination rather than discouraging them, as Einstein admonished_
+
+_Visit from a Dominican business leader and a government official. They spoke about the job market and the government scholarship programs. Students learned about opportunities and requirements._
+
+_Teacher Development. Dominican math teachers participating in two week long math training workshop: improving learning of Basic Algebra._
+
+## First Scholars
+
+MACILE granted five merit-based scholarships in 2008 to 9th-grade students from Itabo and San Gregorio de Nigua. School teachers and directors recommended them. The recommendations were green-lighted by community leaders who attested of the students' characters and needs.
+
+## MACILE Scholarship Program
+
+The program was founded in 2008 with a generous donation from Buffalo Tungstein, Inc.
+
+MACILE pre-college scholarships encourage academic excellence. The program increases opportunities for qualified young people from less advantaged backgrounds, who are interested in math, science, technology, and engineering to attend more challenging schools and pursue their dreams of education.
+
+The program began in 2008. It's open to students in grade 7th to 12th who have participated in the MACILE Summer Academy. The amount of each scholarship varies depending on the school—each covers tuition (when applicable), uniform, books, supplies, and transportation costs. We hope to be able to offer 40-50 pre-college scholarships per year by 2012. 
+
+_Luiz Manuel Alburquerque, 9th grade, Colegio Padre Zegri, Nigua._
+
+_Elizabeth Ramirez, 9th grade, Colegio Padre Zegri, Nigua._
+
+_Luz B. Pinalez, 9th grade, Instituto Politécnico Loyola, San Cristóbal._
+
+_Albania Martinez, 9th grade, Loyola, San Cristóbal._
+
+_Andreina De Jesús T., 9th grade, Colegio Padre Zegri, Nigua._

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -17,7 +17,7 @@ The 2007 MACILE Summer Academy lasted for three weeks and included mathematics o
 
 _People that made a difference. Itabo elementary school director(far left), 6th history and Spanish teacher (far right), and community leaders. They visited the schools, selected students, provided the space, and assisted with logistics_
 
-_MACILE Summer Academy 2007. Group of 7th-8th grade students from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Pinales (far right), Dominican teacher that recruited the students._
+_Group of 7th-8th grade students from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina that participated in the MACILE Summer Academy 2007. Yahaira Pinales (center right), Dominican teacher that recruited the students (top right)._
 
 
 ## MACILE Summer Academy 2008

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -1,10 +1,10 @@
-# We are the adventurers
-
-We are the adventurers; the true founders. High school students from Itabo y San Gregorio de Nigua selected for the FIRST MACILE Summer Academy, Jul 2007.
-
-## MACILE Summer Academy
+# We are the adventurers—-the true founders
 
 The MACILE Summer Academy is a rigorous five week program for students in grades 6 to 12. The curriculum includes math, science, engineering, technology, and language. Courses and activities are designed to stimulate curiosity, creativity, and passion for learning; also to build the students’ skills, analytical abilities, and rational thinking. The program was piloted in July 2007 and 2008.
+
+_High school students from Itabo y San Gregorio de Nigua selected for the FIRST MACILE Summer Academy, July 2007._
+
+## MACILE 2007 Summer Academy
 
 The 2007 MACILE Summer Academy lasted for three weeks and included mathematics only. Forty-seven students completed the program. They attended from 8:00 AM to 12:00 PM, Monday through Friday, and a healthy breakfast snack was provided. We celebrated the end of the summer with a barbeque.
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -4,6 +4,13 @@ The MACILE Summer Academy is a rigorous five week program for students in grades
 
 _High school students from Itabo y San Gregorio de Nigua selected for the FIRST MACILE Summer Academy, July 2007._
 
+## Objectives
+
+- Nurture the creativity and curiosity of talented young people.
+- Increase access to challenging and stimulating learning environments.
+- Advance engineering education in K-12
+- Increase learning and understanding.
+
 ## MACILE 2007 Summer Academy
 
 The 2007 MACILE Summer Academy lasted for three weeks and included mathematics only. Forty-seven students completed the program. They attended from 8:00 AM to 12:00 PM, Monday through Friday, and a healthy breakfast snack was provided. We celebrated the end of the summer with a barbeque.
@@ -12,12 +19,6 @@ _People that made a difference. Itabo elementary school director(far left), 6th 
 
 _MACILE Summer Academy 2007. Group of 7th-8th grade students from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Pinales (far right), Dominican teacher that recruited the students._
 
-### Objectives
-
-- Nurture the creativity and curiosity of talented young people.
-- Increase access to challenging and stimulating learning environments.
-- Advance engineering education in K-12
-- Increase learning and understanding.
 
 ## MACILE Summer Academy 2008
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -1,6 +1,7 @@
 # We are the adventurers—-the true founders
 
-The MACILE Summer Academy is a rigorous five week program for students in grades 6 to 12. The curriculum includes math, science, engineering, technology, and language. Courses and activities are designed to stimulate curiosity, creativity, and passion for learning; also to build the students’ skills, analytical abilities, and rational thinking. The program was piloted in July 2007 and 2008.
+The MACILE Summer Academy is a rigorous five-week program for students in grades 6 to 12. The curriculum includes math, science, engineering, technology, and language. We designed the courses and activities to stimulate curiosity, creativity, and passion for learning; and to build the students’ skills, analytical abilities, and rational thinking. 
+MACILE targets talented students in the top 20% of their class.  We piloted the program in July 207 and 2008.
 
 _High school students from Itabo y San Gregorio de Nigua selected for the FIRST MACILE Summer Academy, July 2007._
 
@@ -13,61 +14,59 @@ _High school students from Itabo y San Gregorio de Nigua selected for the FIRST 
 
 ## MACILE 2007 Summer Academy
 
-The 2007 MACILE Summer Academy lasted for three weeks and included mathematics only. Forty-seven students completed the program. They attended from 8:00 AM to 12:00 PM, Monday through Friday, and a healthy breakfast snack was provided. We celebrated the end of the summer with a barbeque.
+Forty-seven students completed the 2007 MACILE Summer Academy. It lasted for three weeks and only included mathematics. Students attended from 8:00 AM to 12:00 PM, Monday through Friday. We provided a healthy breakfast snack. At the end of the program, we celebrated with a barbeque.
 
-_Group of 7th-8th grade students from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina that participated in the MACILE Summer Academy 2007. Yahaira Pinales (center right), Dominican teacher that recruited the students (top right)._
+_A group of 7th-8th grade students from the MACILE Summer Academy 2007 at the barbeque. Students came from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina. Yahaira Pinales (center right), Dominican teacher that recruited the students (top right)._
 
 ### People that made a difference
 
-Local educators helped us out. They visitted the schools and helped select potential students. They provided us the space and also assisted with logistics.
+Local educators helped us out by visiting the schools and helping select potential students. They provided MACILE space and also assisted with logistics.
 
 _Itabo elementary school director(far left), 6th history and Spanish teacher (far right), and community leaders._
 
 ## MACILE Summer Academy 2008
 
-Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. It was extended to five weeks and we redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers.
+Based on the observations in 2007, we adjusted the 2008 MACILE Summer Academy. We extended the program to five weeks, and we redesigned the curriculum to include engineering, technology, Spanish literacy, in addition to math. We also added activities—chess, field trips, and guest speakers.
 
-### About the 2008 Students
+### About the 2008 Program
 
-MACILE targets talented students in the top 20% of their class. Thirty-five students were admitted and completed the program. There was a required orientation and a meeting with the parents.
+We admitted thirty-five students. We added a required orientation and a meeting with the parents before initiating the program.
 
-### Schedule and Evaluation
+We extended the school day from 12-4 PM and provided students with a healthy lunch in addition to breakfast. We gauged the students' mathematical and linguistic progress through a math test, and an evaluation questionnaire completed at the end of the program.
 
-We extended the school day from 12-4PM and provided students with a healthy lunch in addition to breakfast. We gauged the students' mathematical and linguistic progress through a math test, and an evaluation questionnaire completed at the end of the program.
-
-_MACILE Summer Academy 2007-2008. Conduceted at the Itabo Elementary School in Itabo, San Critóbal._
+_MACILE Summer Academy 2007-2008. Conducted at the Itabo Elementary School in Itabo, San Critóbal._
 
 _Spanish teacher, Antonia Asencio (seating, center), and students, proudly showing resources used to improve their learning._
 
 ## MACILE Spanish Curriculum
 
-An innovative active approach to deepen understanding of the language through the history and folblore of the Dominican Republic. A book written exclusively for MACILE by Dr. Rosario Montelongo de Swanson.
+An innovative active approach to deepen understanding of the language through the history and folklore of the Dominican Republic. Dr. Rosario Montelongo de Swanson wrote a book exclusively for MACILE.
 
 ### Los Indios De Quisqueya
 
-Los indios de Quisqueya, the accompaning history book and foundation of the MACILE curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares Kelnes, permited its use.
+Los Indios de Quisqueya, the accompanying history book and foundation of the MACILE curriculum, was donated by the Tavares Foundation. The author, Juan Tómas Tavares Kelnes, permitted its use.
 
-_Learning language and enjoying the folklore. Students dancing at the bits of the drum and güira, singing the "salve",learning Spanish._
+_Learning language and enjoying the folklore. Students dancing at the bits of the drum and güira, singing the "salve," learning Spanish._
 
-_Students built toothpick bridges and learned about solar energy. This team is testing their bridge resistance._
+_Students built toothpick bridges and learned about solar energy. This team is testing its bridge resistance._
 
-_MACILE strives to expand the young people's horizons,nourishing their innate curiosity and wonderful imagination rather than discouraging them, as Einstein admonished_
+_MACILE strives to expand the young people's horizons, nourishing their innate curiosity and wonderful imagination rather than discouraging them, as Einstein admonished_
 
-_Visit from a Dominican business leader and a government official. They spoke about the job market and the government scholarship programs. Students learned about opportunities and requirements._
+_A visit from a Dominican business leader and a government official. They spoke about the job market. Students learned about opportunities and requirements for government scholarship programs._
 
-_Teacher Development. Dominican math teachers participating in two week long math training workshop: improving learning of Basic Algebra._
+_Teacher Development. Dominican math teachers participating in a two-week-long math training workshop: Improving the Learning of Basic Algebra._
 
 ## MACILE Scholarship Program
 
-The program was founded in 2008 with a generous donation from Buffalo Tungstein, Inc.
-
 MACILE pre-college scholarships encourage academic excellence. The program increases opportunities for qualified young people from less advantaged backgrounds, who are interested in math, science, technology, and engineering to attend more challenging schools and pursue their dreams of education.
 
-The program began in 2008. It's open to students in grade 7th to 12th who have participated in the MACILE Summer Academy. The amount of each scholarship varies depending on the school—each covers tuition (when applicable), uniform, books, supplies, and transportation costs. We hope to be able to offer 40-50 pre-college scholarships per year by 2012. 
+It's open to students in grades 7th to 12th who have participated in the MACILE Summer Academy. The amount of each scholarship varies depending on the school—each covers tuition (when applicable), uniform, books, supplies, and transportation costs. We hope to be able to offer 40-50 pre-college scholarships per year by 2012. 
+
+The program was founded in 2008 with a generous donation from Buffalo Tungstein, Inc.
 
 ### First Scholars
 
-MACILE granted five merit-based scholarships in 2008 to 9th-grade students from Itabo and San Gregorio de Nigua. School teachers and directors recommended them. The recommendations were green-lighted by community leaders who attested of the students' characters and needs.
+MACILE granted five merit-based scholarships in 2008 to 9th-grade students from Itabo and San Gregorio de Nigua. School teachers and directors recommended them. The recommendations were green-lighted by community leaders who attested to the students' characters and needs.
 
 _Luiz Manuel Alburquerque, 9th grade, Colegio Padre Zegri, Nigua._
 

--- a/content/en-bulletin.md
+++ b/content/en-bulletin.md
@@ -15,10 +15,13 @@ _High school students from Itabo y San Gregorio de Nigua selected for the FIRST 
 
 The 2007 MACILE Summer Academy lasted for three weeks and included mathematics only. Forty-seven students completed the program. They attended from 8:00 AM to 12:00 PM, Monday through Friday, and a healthy breakfast snack was provided. We celebrated the end of the summer with a barbeque.
 
-_People that made a difference. Itabo elementary school director(far left), 6th history and Spanish teacher (far right), and community leaders. They visited the schools, selected students, provided the space, and assisted with logistics_
-
 _Group of 7th-8th grade students from schools in Itabo, Nigua, El 18, Yogo Yogo, and Haina that participated in the MACILE Summer Academy 2007. Yahaira Pinales (center right), Dominican teacher that recruited the students (top right)._
 
+### People that made a difference
+
+Local educators helped us out. They visitted the schools and helped select potential students. They provided us the spac and also assisted with logistics.
+
+_Itabo elementary school director(far left), 6th history and Spanish teacher (far right), and community leaders._
 
 ## MACILE Summer Academy 2008
 

--- a/content/en-landingPage-teasers.md
+++ b/content/en-landingPage-teasers.md
@@ -1,0 +1,11 @@
+# Landing-page Teasers
+## Conquered Steps; Our awesome graudation.
+Conquered steps tell the stories of a group of talented and courageous young people from less-privileged backgrounds in the Dominican Republic, who, motivated by their passion for discovering and learning, undertook the path of education, determined to achieve their goals. Here, they reflect about their journeys, the milestones accomplished, and their's visions. Three of the high school graduates featured in this issue are members of the developer team that produced this first digital issue of the MACILE Newsletter, a further testament of their tenacity. 
+
+## We Are The Adventurers; The real founders.
+The MACILE Summer Academy is a rigorous five-week program for talented students in grades 6th to 12th who loves math and science. We piloted the Academy in July 2007 and 2008. This first issue of the Academy Bulletin highlights developments of these pilot programs, focusing on people that made possible their success, evolution of the curricula and activities, and the results. Most of the beautiful Dominican students and dedicated teachers that participated in 2007 and 2008 continued in the program for three or more years.
+
+## About
+MACILE, which stands for Mathematics, Science, Engineering, and Language, in Spanish, is an education program of Complex Systems Optimization Laboratory dedicated to advancing engineering and technology education in less advantaged communities. It operates in the region of Itabo - San Gregorio de Nigua in the province of San Cristóbal, Dominican Republic. The program was founded in 2007 by SClaudina Vargas, Ph.D. with the support of Diane and Ralph Showalter, founders of Buffalo Tungsten, Inc. 
+
+MACILE nurtures talented young people from less advantaged communities, stimulating their innate curiosity and creativity to develop future innovators, teachers, and leaders with the motivation and inspiration to advance human welfare sustainably. 


### PR DESCRIPTION
I've moved the current bullentin content into markdown format so we can better visualize the hierarchy and flow of content on the page. We need to lay out the content first, then fit it to the design. This way we can insure a narrative flow.

 In subsequent commits I will make proposals for how we can sequentially organize the content.

Sections in italics represent figures and figure captions.